### PR TITLE
feat: tests-only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Options:
   -c, --color    Output colored TAP for better human consumption. Disabled in
                  CI environments if not explicitly set (default: true)
   --no-color     Disable colored TAP, usefull when piping to other tools
+  --tests-only   Check types only for test files
   -h, --help     Print this help guide
 ```
 

--- a/lib/run-one.js
+++ b/lib/run-one.js
@@ -8,6 +8,7 @@ const tsd = /** @type {typeof tsdLite} */ (tsdLite.default)
 /**
  * @typedef TestError
  * @property {string} message
+ * @property {string} [file]
  * @property {number} [row]
  * @property {number} [column]
  */
@@ -43,6 +44,7 @@ const tsd = /** @type {typeof tsdLite} */ (tsdLite.default)
  * //   duration: [1, 123456789],
  * //   errors: [{
  * //     message: "Argument of type 'string' is not assignable ...",
+ * //     file: "/home/lorem/src/fn-with-error.test-d.ts",
  * //     row: 1,
  * //     column: 1,
  * //   }]
@@ -70,6 +72,7 @@ export const runTest = absolutePath => {
 
       return {
         message: error.messageText.toString(),
+        file: error.file.fileName,
         row: position.line + 1,
         column: position.character + 1,
       }

--- a/lib/utils/terminal-text.js
+++ b/lib/utils/terminal-text.js
@@ -71,4 +71,4 @@ export const bold = input => `\u001B[1m${input}\u001B[0m`
  */
 export const removeANSICodes = input =>
   // eslint-disable-next-line no-control-regex
-  input.replace(/\u001B\[\d{1,3}m/g, "")
+  input.replaceAll(/\u001B\[\d{1,3}m/g, "")

--- a/package-lock.json
+++ b/package-lock.json
@@ -9004,11 +9004,6 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/npm/node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "dev": true,
@@ -9235,18 +9230,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/move-file": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
@@ -10164,11 +10147,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/npm/node_modules/infer-owner": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",


### PR DESCRIPTION
We have big codebase that transitioning from js to ts, so we want check types only for test-d.ts files.